### PR TITLE
fix: wrong path when uploading certificates from Windows to Unix

### DIFF
--- a/pkg/core/ssl-deployer/providers/ssh/ssh.go
+++ b/pkg/core/ssl-deployer/providers/ssh/ssh.go
@@ -419,7 +419,7 @@ func writeFileWithSFTP(sshCli *ssh.Client, path string, data []byte) error {
 	}
 	defer sftpCli.Close()
 
-	if err := sftpCli.MkdirAll(filepath.Dir(path)); err != nil {
+	if err := sftpCli.MkdirAll(filepath.ToSlash(filepath.Dir(path))); err != nil {
 		return fmt.Errorf("failed to create remote directory: %w", err)
 	}
 


### PR DESCRIPTION
fix: https://github.com/certimate-go/certimate/issues/805