### PR TITLE
bugfix: get ssl certificates with a low version suite in monitoring

### DIFF
--- a/internal/workflow/node-processor/monitor_node.go
+++ b/internal/workflow/node-processor/monitor_node.go
@@ -2,7 +2,6 @@ package nodeprocessor
 
 import (
 	"context"
-	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"log/slog"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/certimate-go/certimate/internal/domain"
 	xhttp "github.com/certimate-go/certimate/pkg/utils/http"
+	xtls "github.com/certimate-go/certimate/pkg/utils/tls"
 )
 
 type monitorNode struct {
@@ -117,10 +117,7 @@ func (n *monitorNode) Process(ctx context.Context) error {
 
 func (n *monitorNode) tryRetrievePeerCertificates(ctx context.Context, addr, domain, requestPath string) ([]*x509.Certificate, error) {
 	transport := xhttp.NewDefaultTransport()
-	if transport.TLSClientConfig == nil {
-		transport.TLSClientConfig = &tls.Config{}
-	}
-	transport.TLSClientConfig.InsecureSkipVerify = true
+	transport.TLSClientConfig = xtls.NewInsecureConfig()
 
 	client := &http.Client{
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
@@ -138,6 +135,7 @@ func (n *monitorNode) tryRetrievePeerCertificates(ctx context.Context, addr, dom
 		return nil, err
 	}
 
+	req.Header.Set("Host", domain)
 	req.Header.Set("User-Agent", "certimate")
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/utils/tls/config.go
+++ b/pkg/utils/tls/config.go
@@ -1,0 +1,34 @@
+﻿package tls
+
+import (
+	"crypto/tls"
+)
+
+// 创建并返回一个兼容低版的 [tls.Config] 对象。
+//
+// 出参：
+//   - config: [tls.Config] 对象。
+func NewCompatibleConfig() *tls.Config {
+	var suiteIds []uint16
+	for _, suite := range tls.CipherSuites() {
+		suiteIds = append(suiteIds, suite.ID)
+	}
+	for _, suite := range tls.InsecureCipherSuites() {
+		suiteIds = append(suiteIds, suite.ID)
+	}
+
+	return &tls.Config{
+		MinVersion:   tls.VersionTLS10,
+		CipherSuites: suiteIds,
+	}
+}
+
+// 创建并返回一个不安全的 [tls.Config] 对象。
+//
+// 出参：
+//   - config: [tls.Config] 对象。
+func NewInsecureConfig() *tls.Config {
+	config := NewCompatibleConfig()
+	config.InsecureSkipVerify = true
+	return config
+}


### PR DESCRIPTION
该 PR 包含以下内容变更：

- **fix**: 修复证书监控中当连接使用已废弃的低版本 TLS/SSL 密码套件时无法获取证书的问题