### PR TITLE
Refresh providers after save

### DIFF
--- a/ui/src/pages/accesses/AccessList.tsx
+++ b/ui/src/pages/accesses/AccessList.tsx
@@ -472,8 +472,8 @@ const AccessList = () => {
           </Show>
         </div>
 
-        <AccessEditDrawer mode="create" usage={filters["usage"] as AccessUsages} {...createDrawerProps} />
-        <AccessEditDrawer mode="modify" usage={filters["usage"] as AccessUsages} {...detailDrawerProps} />
+        <AccessEditDrawer afterSubmit={() => refreshData()} mode="create" usage={filters["usage"] as AccessUsages} {...createDrawerProps} />
+        <AccessEditDrawer afterSubmit={() => refreshData()} mode="modify" usage={filters["usage"] as AccessUsages} {...detailDrawerProps} />
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #1314

## Summary
- refresh the current Credentials tab after save
- apply to the Provider, Certificate authority, and Notification channel tabs
- remove the need to manually reload after copying a credential

## Verification
- manually copy and save a credential on the Credentials page and confirm the current tab updates immediately