### PR TITLE
Fix wrong Kong response field type and optional ApiToken

### DIFF
--- a/pkg/sdk3rd/kong/client.go
+++ b/pkg/sdk3rd/kong/client.go
@@ -31,9 +31,6 @@ func NewClient(serverUrl string, optFns ...OptionsFunc) (*Client, error) {
 	if _, err := url.Parse(serverUrl); err != nil {
 		return nil, fmt.Errorf("sdkerr: invalid serverUrl: %w", err)
 	}
-	if opts.ApiToken == "" {
-		return nil, fmt.Errorf("sdkerr: unset apiToken")
-	}
 
 	baseUrl := strings.TrimSuffix(serverUrl, "/")
 	if opts.Workspace != "" {
@@ -44,8 +41,11 @@ func NewClient(serverUrl string, optFns ...OptionsFunc) (*Client, error) {
 		SetBaseURL(baseUrl).
 		SetHeader("Accept", "application/json").
 		SetHeader("Content-Type", "application/json").
-		SetHeader("User-Agent", app.AppUserAgent).
-		SetHeader("Kong-Admin-Token", opts.ApiToken)
+		SetHeader("User-Agent", app.AppUserAgent)
+
+	if opts.ApiToken != "" {
+		httper = httper.SetHeader("Kong-Admin-Token", opts.ApiToken)
+	}
 
 	return &Client{rc: httper}, nil
 }

--- a/pkg/sdk3rd/kong/models.go
+++ b/pkg/sdk3rd/kong/models.go
@@ -8,6 +8,6 @@ type Certificate struct {
 	KeyAlt    *string   `json:"key_alt,omitempty"`
 	SNIs      []*string `json:"snis,omitempty"`
 	Tags      []*string `json:"tags,omitempty"`
-	CreatedAt *string   `json:"created_at,omitempty"`
-	UpdatedAt *string   `json:"updated_at,omitempty"`
+	CreatedAt *int64   `json:"created_at,omitempty"`
+	UpdatedAt *int64   `json:"updated_at,omitempty"`
 }


### PR DESCRIPTION
- 修复 Kong 客户端 Certificate 结构体字段 CreatedAt、UpdatedAt 类型错误
- 修复 Kong 客户端 ApiToken 为空时报错
