### PR TITLE
[dev] 支持反向代理子路径部署

### DIFF
--- a/ui/eslint-rules/no-root-relative-url.mjs
+++ b/ui/eslint-rules/no-root-relative-url.mjs
@@ -1,0 +1,51 @@
+const TARGET_ATTRIBUTES = new Set(["href", "src"]);
+
+const getStaticPrefix = (node) => {
+  if (!node) {
+    return;
+  }
+
+  if (node.type === "Literal") {
+    return typeof node.value === "string" ? node.value : void 0;
+  }
+
+  if (node.type === "TemplateLiteral") {
+    return node.quasis[0]?.value.raw;
+  }
+
+  if (node.type === "BinaryExpression" && node.operator === "+") {
+    return getStaticPrefix(node.left);
+  }
+};
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow root-relative URLs in JSX href and src attributes",
+    },
+    messages: {
+      useBasePath: "Root-relative {{attribute}} bypasses the application base path. Wrap the URL with withBasePath().",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      JSXAttribute(node) {
+        const attribute = node.name.type === "JSXIdentifier" ? node.name.name : "";
+        if (!TARGET_ATTRIBUTES.has(attribute)) {
+          return;
+        }
+
+        const value = node.value?.type === "JSXExpressionContainer" ? getStaticPrefix(node.value.expression) : getStaticPrefix(node.value);
+        if (value?.startsWith("/") && !value.startsWith("//")) {
+          context.report({
+            node: node.value ?? node,
+            messageId: "useBasePath",
+            data: { attribute },
+          });
+        }
+      },
+    };
+  },
+};

--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -7,6 +7,14 @@ import reactHooksPlugin from "eslint-plugin-react-hooks";
 import reactRefreshPlugin from "eslint-plugin-react-refresh";
 import typescriptPlugin from "typescript-eslint";
 
+import noRootRelativeUrlRule from "./eslint-rules/no-root-relative-url.mjs";
+
+const certimatePlugin = {
+  rules: {
+    "no-root-relative-url": noRootRelativeUrlRule,
+  },
+};
+
 /**
  * @type {import("eslint").Linter.Config[]}
  */
@@ -134,6 +142,17 @@ export default defineConfig(
           allowConstantExport: true,
         },
       ],
+    },
+  },
+
+  // Certimate
+  {
+    name: "certimate",
+    plugins: {
+      certimate: certimatePlugin,
+    },
+    rules: {
+      "certimate/no-root-relative-url": "error",
     },
   },
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="robots" content="noindex" />
     <title>Certimate - Your Trusted Partner in SSL Automation</title>

--- a/ui/src/domain/provider.ts
+++ b/ui/src/domain/provider.ts
@@ -1,3 +1,5 @@
+import { resolveAppPath } from "@/utils/url";
+
 interface BaseProvider<P> {
   type: P;
   name: string;
@@ -296,7 +298,7 @@ export const accessProvidersMap: Map<AccessProvider["type"] | string, AccessProv
     {
       type: type,
       name: name,
-      icon: icon,
+      icon: resolveAppPath(icon),
       usages: usages,
       builtin: builtin === "builtin",
     },

--- a/ui/src/domain/provider.ts
+++ b/ui/src/domain/provider.ts
@@ -1,4 +1,4 @@
-import { resolveAppPath } from "@/utils/url";
+import { withBasePath } from "@/utils/url";
 
 interface BaseProvider<P> {
   type: P;
@@ -298,7 +298,7 @@ export const accessProvidersMap: Map<AccessProvider["type"] | string, AccessProv
     {
       type: type,
       name: name,
-      icon: resolveAppPath(icon),
+      icon: withBasePath(icon),
       usages: usages,
       builtin: builtin === "builtin",
     },

--- a/ui/src/pages/ConsoleLayout.tsx
+++ b/ui/src/pages/ConsoleLayout.tsx
@@ -25,6 +25,7 @@ import { APP_DOCUMENT_URL, APP_REPO_URL } from "@/domain/app";
 import { useTriggerElement } from "@/hooks";
 import { getAuthStore } from "@/repository/admin";
 import { isBrowserHappy } from "@/utils/browser";
+import { resolveAppPath } from "@/utils/url";
 
 const ConsoleLayout = () => {
   const navigate = useNavigate();
@@ -231,7 +232,7 @@ const SiderMenu = memo(({ collapsed, onSelect }: { collapsed?: boolean; onSelect
     <>
       <div className="h-[64px] w-full overflow-hidden px-4 py-2 max-md:py-0">
         <div className="flex size-full items-center justify-around gap-2">
-          <img src="/logo.svg" className="size-[36px]" />
+          <img src={resolveAppPath("/logo.svg")} className="size-[36px]" />
           <Show when={!collapsed}>
             <span className="w-[81px] truncate text-base leading-[64px] font-semibold">Certimate</span>
             <AppVersion.LinkButton className="text-xs" />

--- a/ui/src/pages/ConsoleLayout.tsx
+++ b/ui/src/pages/ConsoleLayout.tsx
@@ -25,7 +25,7 @@ import { APP_DOCUMENT_URL, APP_REPO_URL } from "@/domain/app";
 import { useTriggerElement } from "@/hooks";
 import { getAuthStore } from "@/repository/admin";
 import { isBrowserHappy } from "@/utils/browser";
-import { resolveAppPath } from "@/utils/url";
+import { withBasePath } from "@/utils/url";
 
 const ConsoleLayout = () => {
   const navigate = useNavigate();
@@ -232,7 +232,7 @@ const SiderMenu = memo(({ collapsed, onSelect }: { collapsed?: boolean; onSelect
     <>
       <div className="h-[64px] w-full overflow-hidden px-4 py-2 max-md:py-0">
         <div className="flex size-full items-center justify-around gap-2">
-          <img src={resolveAppPath("/logo.svg")} className="size-[36px]" />
+          <img src={withBasePath("/logo.svg")} className="size-[36px]" />
           <Show when={!collapsed}>
             <span className="w-[81px] truncate text-base leading-[64px] font-semibold">Certimate</span>
             <AppVersion.LinkButton className="text-xs" />

--- a/ui/src/pages/login/Login.tsx
+++ b/ui/src/pages/login/Login.tsx
@@ -14,7 +14,7 @@ import { useAntdForm, useBrowserTheme } from "@/hooks";
 
 import { authWithPassword } from "@/repository/admin";
 import { unwrapErrMsg } from "@/utils/error";
-import { resolveAppPath } from "@/utils/url";
+import { withBasePath } from "@/utils/url";
 
 const Login = () => {
   const navigage = useNavigate();
@@ -75,7 +75,7 @@ const Login = () => {
         <Card className="w-120 max-w-full rounded-md shadow-md max-sm:size-full max-sm:rounded-none">
           <div className="px-4 py-8">
             <div className="mb-12 flex items-center justify-center">
-              <img src={resolveAppPath("/logo.svg")} className="w-16" />
+              <img src={withBasePath("/logo.svg")} className="w-16" />
             </div>
 
             <Form {...formProps} form={formInst} disabled={formPending} layout="vertical" validateTrigger="onBlur">

--- a/ui/src/pages/login/Login.tsx
+++ b/ui/src/pages/login/Login.tsx
@@ -14,6 +14,7 @@ import { useAntdForm, useBrowserTheme } from "@/hooks";
 
 import { authWithPassword } from "@/repository/admin";
 import { unwrapErrMsg } from "@/utils/error";
+import { resolveAppPath } from "@/utils/url";
 
 const Login = () => {
   const navigage = useNavigate();
@@ -74,7 +75,7 @@ const Login = () => {
         <Card className="w-120 max-w-full rounded-md shadow-md max-sm:size-full max-sm:rounded-none">
           <div className="px-4 py-8">
             <div className="mb-12 flex items-center justify-center">
-              <img src="/logo.svg" className="w-16" />
+              <img src={resolveAppPath("/logo.svg")} className="w-16" />
             </div>
 
             <Form {...formProps} form={formInst} disabled={formPending} layout="vertical" validateTrigger="onBlur">

--- a/ui/src/pages/settings/SettingsAppearance.tsx
+++ b/ui/src/pages/settings/SettingsAppearance.tsx
@@ -6,6 +6,7 @@ import { produce } from "immer";
 import { useAppLocaleMenuItems } from "@/components/AppLocale";
 import { useAppThemeMenuItems } from "@/components/AppTheme";
 import { useAppSettings, useBrowserTheme } from "@/hooks";
+import { resolveAppPath } from "@/utils/url";
 
 const SettingsAppearance = () => {
   const { t } = useTranslation();
@@ -58,7 +59,7 @@ const SettingsAppearanceTheme = ({ className, style }: { className?: string; sty
               {themeItems.map((item) => (
                 <div className="relative max-w-44 flex-1/3 max-md:flex-1/2 max-sm:flex-1" key={item.key}>
                   <div className="overflow-hidden rounded-lg border border-solid" style={{ borderColor: themeToken.colorBorder }}>
-                    <img className="mb-2 w-full" src={`/imgs/themes/${item.key}.png`} />
+                    <img className="mb-2 w-full" src={resolveAppPath(`/imgs/themes/${item.key}.png`)} />
                     <div className="mb-2 px-2">
                       <Radio value={item.key}>{item.label}</Radio>
                     </div>

--- a/ui/src/pages/settings/SettingsAppearance.tsx
+++ b/ui/src/pages/settings/SettingsAppearance.tsx
@@ -6,7 +6,7 @@ import { produce } from "immer";
 import { useAppLocaleMenuItems } from "@/components/AppLocale";
 import { useAppThemeMenuItems } from "@/components/AppTheme";
 import { useAppSettings, useBrowserTheme } from "@/hooks";
-import { resolveAppPath } from "@/utils/url";
+import { withBasePath } from "@/utils/url";
 
 const SettingsAppearance = () => {
   const { t } = useTranslation();
@@ -59,7 +59,7 @@ const SettingsAppearanceTheme = ({ className, style }: { className?: string; sty
               {themeItems.map((item) => (
                 <div className="relative max-w-44 flex-1/3 max-md:flex-1/2 max-sm:flex-1" key={item.key}>
                   <div className="overflow-hidden rounded-lg border border-solid" style={{ borderColor: themeToken.colorBorder }}>
-                    <img className="mb-2 w-full" src={resolveAppPath(`/imgs/themes/${item.key}.png`)} />
+                    <img className="mb-2 w-full" src={withBasePath(`/imgs/themes/${item.key}.png`)} />
                     <div className="mb-2 px-2">
                       <Radio value={item.key}>{item.label}</Radio>
                     </div>

--- a/ui/src/pages/workflows/WorkflowNew.tsx
+++ b/ui/src/pages/workflows/WorkflowNew.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/domain/workflow";
 import { save as saveWorkflow } from "@/repository/workflow";
 import { unwrapErrMsg } from "@/utils/error";
+import { resolveAppPath } from "@/utils/url";
 
 const TEMPLATE_KEY_BLANK = "blank" as const;
 const TEMPLATE_KEY_STANDARD = "standard" as const;
@@ -34,13 +35,13 @@ const WorkflowNew = () => {
       key: TEMPLATE_KEY_STANDARD,
       name: t("workflow.new.templates.template.standard.title"),
       description: t("workflow.new.templates.template.standard.description"),
-      image: "/imgs/workflow/tpl-standard.png",
+      image: resolveAppPath("/imgs/workflow/tpl-standard.png"),
     },
     {
       key: TEMPLATE_KEY_CERTTEST,
       name: t("workflow.new.templates.template.certtest.title"),
       description: t("workflow.new.templates.template.certtest.description"),
-      image: "/imgs/workflow/tpl-certtest.png",
+      image: resolveAppPath("/imgs/workflow/tpl-certtest.png"),
     },
   ];
   const [templateSelectKey, setTemplateSelectKey] = useState<TemplateKeys>();

--- a/ui/src/pages/workflows/WorkflowNew.tsx
+++ b/ui/src/pages/workflows/WorkflowNew.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/domain/workflow";
 import { save as saveWorkflow } from "@/repository/workflow";
 import { unwrapErrMsg } from "@/utils/error";
-import { resolveAppPath } from "@/utils/url";
+import { withBasePath } from "@/utils/url";
 
 const TEMPLATE_KEY_BLANK = "blank" as const;
 const TEMPLATE_KEY_STANDARD = "standard" as const;
@@ -35,13 +35,13 @@ const WorkflowNew = () => {
       key: TEMPLATE_KEY_STANDARD,
       name: t("workflow.new.templates.template.standard.title"),
       description: t("workflow.new.templates.template.standard.description"),
-      image: resolveAppPath("/imgs/workflow/tpl-standard.png"),
+      image: withBasePath("/imgs/workflow/tpl-standard.png"),
     },
     {
       key: TEMPLATE_KEY_CERTTEST,
       name: t("workflow.new.templates.template.certtest.title"),
       description: t("workflow.new.templates.template.certtest.description"),
-      image: resolveAppPath("/imgs/workflow/tpl-certtest.png"),
+      image: withBasePath("/imgs/workflow/tpl-certtest.png"),
     },
   ];
   const [templateSelectKey, setTemplateSelectKey] = useState<TemplateKeys>();

--- a/ui/src/repository/_pocketbase.ts
+++ b/ui/src/repository/_pocketbase.ts
@@ -1,9 +1,11 @@
 import PocketBase from "pocketbase";
 
+import { APP_BASE_PATH } from "@/utils/url";
+
 let pb: PocketBase;
 export const getPocketBase = () => {
   if (pb) return pb;
-  pb = new PocketBase("/");
+  pb = new PocketBase(APP_BASE_PATH);
   pb.afterSend = (res, data) => {
     if ((res.status === 401 || res.status === 403) && pb.authStore?.isValid) {
       pb.authStore.clear();

--- a/ui/src/utils/url.ts
+++ b/ui/src/utils/url.ts
@@ -1,8 +1,15 @@
 const appBaseUrl = new URL(import.meta.env.BASE_URL, document.baseURI);
+const urlSchemePattern = /^[a-z][a-z\d+.-]*:/i;
 
 // PocketBase 会把自身的 /api 路径拼接到这里，因此基础路径必须以斜杠结尾。
 export const APP_BASE_PATH = appBaseUrl.pathname;
 
-export const resolveAppPath = (path: string) => {
-  return new URL(path.replace(/^\/+/, ""), appBaseUrl).pathname;
+export const withBasePath = (path: string) => {
+  // 完整 URL 和协议相对 URL 不属于应用内资源，保持调用方传入的地址不变。
+  if (urlSchemePattern.test(path) || path.startsWith("//")) {
+    return path;
+  }
+
+  const url = new URL(path.replace(/^\/+/, ""), appBaseUrl);
+  return `${url.pathname}${url.search}${url.hash}`;
 };

--- a/ui/src/utils/url.ts
+++ b/ui/src/utils/url.ts
@@ -1,0 +1,8 @@
+const appBaseUrl = new URL(import.meta.env.BASE_URL, document.baseURI);
+
+// PocketBase 会把自身的 /api 路径拼接到这里，因此基础路径必须以斜杠结尾。
+export const APP_BASE_PATH = appBaseUrl.pathname;
+
+export const resolveAppPath = (path: string) => {
+  return new URL(path.replace(/^\/+/, ""), appBaseUrl).pathname;
+};

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -52,6 +52,8 @@ export default defineConfig(({ command }) => {
   }
 
   return {
+    // 使用相对基础路径，让同一份构建产物可以部署在根路径或任意反向代理子路径下。
+    base: "./",
     define: {
       __APP_VERSION__: JSON.stringify(appVersion),
     },


### PR DESCRIPTION
## 变更说明

- 使用 Vite 相对基础路径构建 WebUI，使同一份构建产物既可以部署在域名根路径，也可以部署在任意反向代理子路径下。
- 运行时根据 `import.meta.env.BASE_URL` 和 `document.baseURI` 计算应用的实际基础路径。
- PocketBase、自定义 API 请求以及 Logo、服务商图标、主题预览图、工作流模板图等公共资源统一使用该基础路径。
- 后端仍然挂载在 `/`，不要求 PocketBase 服务端支持 `baseurl`，也不需要为 Certimate 增加运行时配置。

## 与 #1026 的区别

之前的 PR 是将各处资源地址直接修改为 `./...`。本实现集中处理路径解析，并使用浏览器中的实际路径（例如 `/certimate/`）初始化 PocketBase 客户端，避免逐处替换相对路径，同时保持根路径部署兼容。

反向代理在转发时会移除外部子路径前缀，因此本方案不依赖 PocketBase 服务端提供基础路径功能。

## Nginx 配置示例

```nginx
location = /certimate {
    return 301 /certimate/;
}

location /certimate/ {
    proxy_set_header Host $host;
    proxy_set_header Connection upgrade;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Host $server_name;
    proxy_set_header X-Forwarded-Proto $scheme;

    proxy_pass http://127.0.0.1:8090/;
    proxy_redirect / /certimate/;
}
```

两个末尾斜杠均需要保留：入口地址统一为 `/certimate/`，Nginx 转发请求时移除外部路径前缀。

## 验证结果

- `npm run build`
- 对本次变更的 TypeScript 文件执行 ESLint 检查
- `go build`
- 分别通过根路径 `/` 和子路径 `/ce/` 进行浏览器验证：
  - 登录及 PocketBase 认证 API
  - 自定义 API 请求
  - 服务商图标
  - 主题预览图
  - 工作流模板图

## 相关问题

- 主要需求：#359
- 相同需求：#709
- 早期反向代理问题：#177
- 之前的实现：#1026
