### PR TITLE
fix(k8s-secret): set GroupVersion and NegotiatedSerializer for in-cluster config

### DIFF
--- a/pkg/core/deployer/providers/k8s-secret/k8s_secret.go
+++ b/pkg/core/deployer/providers/k8s-secret/k8s_secret.go
@@ -9,6 +9,8 @@ import (
 	k8score "k8s.io/api/core/v1"
 	k8serrs "k8s.io/apimachinery/pkg/api/errors"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -220,6 +222,15 @@ func createK8sClient(kubeConfig string) (*rest.RESTClient, error) {
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	// InClusterConfig does not set GroupVersion or NegotiatedSerializer,
+	// but both are required by rest.RESTClientFor.
+	if config.GroupVersion == nil {
+		config.GroupVersion = &schema.GroupVersion{Group: "", Version: "v1"}
+	}
+	if config.NegotiatedSerializer == nil {
+		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
 	}
 
 	client, err := rest.RESTClientFor(config)


### PR DESCRIPTION
## Description

Fixes #1412

`rest.InClusterConfig()` and `clientcmd.ClientConfig()` both return a `*rest.Config` without `GroupVersion` or `NegotiatedSerializer` set, but `rest.RESTClientFor()` requires both. When either path is used, the deployer fails with:

```
failed to create kubernetes client: GroupVersion is required when initializing a RESTClient
```

This was introduced by the June 23 refactor that switched from `kubernetes.NewForConfig()` (which sets these internally) to raw `rest.RESTClientFor()`.

## Fix

Sets the required fields before calling `RESTClientFor`, matching the standard client-go pattern used by `kubernetes.NewForConfig()`. The check runs after both code paths (in-cluster and kubeconfig), so both are covered.

## Testing

- In-cluster mode (no kubeconfig): reproduced the error, confirmed fix resolves it
- Kubeconfig mode: reproduced the same error, confirmed fix resolves it