### PR TITLE
fix: keep skip-before-expiry working after workflow history cleanup

### DIFF
--- a/internal/workflow/engine/certificate_lookup.go
+++ b/internal/workflow/engine/certificate_lookup.go
@@ -1,0 +1,51 @@
+package engine
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/certimate-go/certimate/internal/domain"
+)
+
+// resolveLastCertificateForNode finds the certificate that should drive skip/renew decisions.
+//
+// Lookup order:
+//  1. certificate#id ref stored in the last workflow_output (works after skip-only runs,
+//     where the cert's workflowRunRef still points at the original apply run);
+//  2. certificate by lastOutput.RunId + nodeId (legacy apply-run path);
+//  3. latest certificate by workflowId + nodeId (survives workflow run history cleanup
+//     that cascade-deletes workflow_output).
+func resolveLastCertificateForNode(execCtx *NodeExecutionContext, certRepo certificateRepository, lastOutput *domain.WorkflowOutput) (*domain.Certificate, error) {
+	if lastOutput != nil {
+		for _, entry := range lastOutput.Outputs {
+			if entry == nil || entry.Name != "certificate" || entry.Type != stateIOTypeRef {
+				continue
+			}
+			parts := strings.Split(entry.Value, "#")
+			if len(parts) != 2 || parts[0] != domain.CollectionNameCertificate || parts[1] == "" {
+				continue
+			}
+			certificate, err := certRepo.GetById(execCtx.Context(), parts[1])
+			if err != nil && !domain.IsRecordNotFoundError(err) {
+				return nil, fmt.Errorf("failed to get last certificate record of node #%s: %w", execCtx.Node.Id, err)
+			}
+			if certificate != nil {
+				return certificate, nil
+			}
+		}
+
+		certificate, err := certRepo.GetByWorkflowRunIdAndNodeId(execCtx.Context(), lastOutput.RunId, lastOutput.NodeId)
+		if err != nil && !domain.IsRecordNotFoundError(err) {
+			return nil, fmt.Errorf("failed to get last certificate record of node #%s: %w", execCtx.Node.Id, err)
+		}
+		if certificate != nil {
+			return certificate, nil
+		}
+	}
+
+	certificate, err := certRepo.GetByWorkflowIdAndNodeId(execCtx.Context(), execCtx.WorkflowId, execCtx.Node.Id)
+	if err != nil && !domain.IsRecordNotFoundError(err) {
+		return nil, fmt.Errorf("failed to get last certificate record of node #%s: %w", execCtx.Node.Id, err)
+	}
+	return certificate, nil
+}

--- a/internal/workflow/engine/deps.go
+++ b/internal/workflow/engine/deps.go
@@ -12,6 +12,7 @@ type accessRepository interface {
 
 type certificateRepository interface {
 	GetById(ctx context.Context, id string) (*domain.Certificate, error)
+	GetByWorkflowIdAndNodeId(ctx context.Context, workflowId string, workflowNodeId string) (*domain.Certificate, error)
 	GetByWorkflowRunIdAndNodeId(ctx context.Context, workflowRunId string, workflowNodeId string) (*domain.Certificate, error)
 	Save(ctx context.Context, certificate *domain.Certificate) (*domain.Certificate, error)
 }

--- a/internal/workflow/engine/executor_bizapply.go
+++ b/internal/workflow/engine/executor_bizapply.go
@@ -85,6 +85,13 @@ func (ne *bizApplyNodeExecutor) Execute(execCtx *NodeExecutionContext) (*NodeExe
 	if skippable, reason := ne.checkCanSkip(execCtx, lastOutput, lastCertificate); skippable {
 		ne.logger.Info(fmt.Sprintf("skip this application, because %s", reason))
 
+		// Persist so skip runs keep a durable trail for the next skip decision.
+		// workflow_output rows cascade-delete with history cleanup; without a
+		// recent output the node would re-apply despite a still-valid certificate.
+		if lastCertificate != nil {
+			ne.setOuputsOfResult(execCtx, execRes, lastCertificate, true)
+		}
+
 		execRes.AddVariableWithScope(execCtx.Node.Id, stateVarKeyNodeSkipped, true, stateValTypeBoolean)
 		return execRes, nil
 	} else {
@@ -144,16 +151,12 @@ func (ne *bizApplyNodeExecutor) getLastOutputArtifacts(execCtx *NodeExecutionCon
 		return nil, nil, fmt.Errorf("failed to get last output record of node #%s: %w", execCtx.Node.Id, err)
 	}
 
-	if lastOutput != nil {
-		lastCertificate, err := ne.certificateRepo.GetByWorkflowRunIdAndNodeId(execCtx.Context(), lastOutput.RunId, lastOutput.NodeId)
-		if err != nil && !domain.IsRecordNotFoundError(err) {
-			return lastOutput, nil, fmt.Errorf("failed to get last certificate record of node #%s: %w", execCtx.Node.Id, err)
-		}
-
-		return lastOutput, lastCertificate, nil
+	lastCertificate, err := resolveLastCertificateForNode(execCtx, ne.certificateRepo, lastOutput)
+	if err != nil {
+		return lastOutput, nil, err
 	}
 
-	return lastOutput, nil, nil
+	return lastOutput, lastCertificate, nil
 }
 
 func (ne *bizApplyNodeExecutor) checkCanSkip(execCtx *NodeExecutionContext, lastOutput *domain.WorkflowOutput, lastCertificate *domain.Certificate) (_skip bool, _reason string) {

--- a/internal/workflow/engine/executor_bizapply_test.go
+++ b/internal/workflow/engine/executor_bizapply_test.go
@@ -1,0 +1,279 @@
+package engine
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/certimate-go/certimate/internal/domain"
+)
+
+type mockCertificateRepo struct {
+	byId              map[string]*domain.Certificate
+	byWorkflowAndNode map[string]*domain.Certificate
+	byRunAndNode      map[string]*domain.Certificate
+}
+
+func (m *mockCertificateRepo) GetById(ctx context.Context, id string) (*domain.Certificate, error) {
+	if cert, ok := m.byId[id]; ok {
+		return cert, nil
+	}
+	return nil, domain.ErrRecordNotFound
+}
+
+func (m *mockCertificateRepo) GetByWorkflowIdAndNodeId(ctx context.Context, workflowId string, workflowNodeId string) (*domain.Certificate, error) {
+	if cert, ok := m.byWorkflowAndNode[workflowId+"|"+workflowNodeId]; ok {
+		return cert, nil
+	}
+	return nil, domain.ErrRecordNotFound
+}
+
+func (m *mockCertificateRepo) GetByWorkflowRunIdAndNodeId(ctx context.Context, workflowRunId string, workflowNodeId string) (*domain.Certificate, error) {
+	if cert, ok := m.byRunAndNode[workflowRunId+"|"+workflowNodeId]; ok {
+		return cert, nil
+	}
+	return nil, domain.ErrRecordNotFound
+}
+
+func (m *mockCertificateRepo) Save(ctx context.Context, certificate *domain.Certificate) (*domain.Certificate, error) {
+	if m.byId == nil {
+		m.byId = make(map[string]*domain.Certificate)
+	}
+	m.byId[certificate.Id] = certificate
+	return certificate, nil
+}
+
+type mockWorkflowOutputRepo struct {
+	byWorkflowAndNode map[string]*domain.WorkflowOutput
+}
+
+func (m *mockWorkflowOutputRepo) GetByWorkflowIdAndNodeId(ctx context.Context, workflowId string, workflowNodeId string) (*domain.WorkflowOutput, error) {
+	if out, ok := m.byWorkflowAndNode[workflowId+"|"+workflowNodeId]; ok {
+		return out, nil
+	}
+	return nil, domain.ErrRecordNotFound
+}
+
+func (m *mockWorkflowOutputRepo) Save(ctx context.Context, workflowOutput *domain.WorkflowOutput) (*domain.WorkflowOutput, error) {
+	if m.byWorkflowAndNode == nil {
+		m.byWorkflowAndNode = make(map[string]*domain.WorkflowOutput)
+	}
+	m.byWorkflowAndNode[workflowOutput.WorkflowId+"|"+workflowOutput.NodeId] = workflowOutput
+	return workflowOutput, nil
+}
+
+func newTestApplyExecutor(certRepo certificateRepository, outputRepo workflowOutputRepository) *bizApplyNodeExecutor {
+	ne := &bizApplyNodeExecutor{
+		accessRepo:      nil,
+		certificateRepo: certRepo,
+		wfoutputRepo:    outputRepo,
+	}
+	ne.SetLogger(slog.Default())
+	return ne
+}
+
+func newTestApplyExecCtx(workflowId, runId, nodeId string, cfg domain.WorkflowNodeConfig) *NodeExecutionContext {
+	node := &Node{
+		Id:   nodeId,
+		Type: NodeTypeBizApply,
+		Data: domain.WorkflowNodeData{
+			Name:   "apply",
+			Config: cfg,
+		},
+	}
+	return (&NodeExecutionContext{}).
+		SetExecutingWorkflow(workflowId, runId, nil).
+		SetExecutingNode(node).
+		SetContext(context.Background())
+}
+
+func TestBizApply_resolveLastCertificate_fallbackWhenOutputMissing(t *testing.T) {
+	// Reproduces #1413: workflow_output cascade-deleted with run history cleanup,
+	// but the certificate still exists and should keep skip-before-expiry working.
+	cert := &domain.Certificate{
+		Meta:             domain.Meta{Id: "cert-alive"},
+		WorkflowId:       "wf1",
+		WorkflowRunId:    "run-old",
+		WorkflowNodeId:   "node-apply",
+		ValidityNotAfter: time.Now().Add(60 * 24 * time.Hour),
+	}
+	certRepo := &mockCertificateRepo{
+		byWorkflowAndNode: map[string]*domain.Certificate{
+			"wf1|node-apply": cert,
+		},
+	}
+	outputRepo := &mockWorkflowOutputRepo{} // no outputs
+
+	ne := newTestApplyExecutor(certRepo, outputRepo)
+	execCtx := newTestApplyExecCtx("wf1", "run-new", "node-apply", domain.WorkflowNodeConfig{
+		"domains":              []any{"example.com"},
+		"skipBeforeExpiryDays": 30,
+	})
+
+	lastOutput, lastCertificate, err := ne.getLastOutputArtifacts(execCtx)
+	require.NoError(t, err)
+	assert.Nil(t, lastOutput)
+	require.NotNil(t, lastCertificate)
+	assert.Equal(t, "cert-alive", lastCertificate.Id)
+
+	skippable, reason := ne.checkCanSkip(execCtx, lastOutput, lastCertificate)
+	assert.True(t, skippable, "expected skip when remaining validity is well above threshold; reason=%q", reason)
+	assert.Contains(t, reason, "renewal will be performed when the remaining validity is less than")
+}
+
+func TestBizApply_resolveLastCertificate_prefersOutputRefOverRunId(t *testing.T) {
+	// After a skip-only run, workflow_output.runRef is the skip run, while the
+	// certificate still points at the original apply run. Resolve via certificate#id ref.
+	cert := &domain.Certificate{
+		Meta:             domain.Meta{Id: "cert-from-ref"},
+		WorkflowId:       "wf1",
+		WorkflowRunId:    "run-apply",
+		WorkflowNodeId:   "node-apply",
+		ValidityNotAfter: time.Now().Add(60 * 24 * time.Hour),
+	}
+	wrongCert := &domain.Certificate{
+		Meta: domain.Meta{Id: "should-not-use"},
+	}
+	certRepo := &mockCertificateRepo{
+		byId: map[string]*domain.Certificate{
+			"cert-from-ref": cert,
+		},
+		byRunAndNode: map[string]*domain.Certificate{
+			// Would be used if we only looked up by lastOutput.RunId
+			"run-skip|node-apply": wrongCert,
+		},
+	}
+	outputRepo := &mockWorkflowOutputRepo{
+		byWorkflowAndNode: map[string]*domain.WorkflowOutput{
+			"wf1|node-apply": {
+				WorkflowId: "wf1",
+				RunId:      "run-skip",
+				NodeId:     "node-apply",
+				Succeeded:  true,
+				Outputs: []*domain.WorkflowOutputEntry{
+					{
+						Type:      stateIOTypeRef,
+						Name:      "certificate",
+						Value:     domain.CollectionNameCertificate + "#cert-from-ref",
+						ValueType: stateValTypeString,
+					},
+				},
+			},
+		},
+	}
+
+	ne := newTestApplyExecutor(certRepo, outputRepo)
+	execCtx := newTestApplyExecCtx("wf1", "run-next", "node-apply", domain.WorkflowNodeConfig{
+		"domains":              []any{"example.com"},
+		"skipBeforeExpiryDays": 30,
+	})
+
+	_, lastCertificate, err := ne.getLastOutputArtifacts(execCtx)
+	require.NoError(t, err)
+	require.NotNil(t, lastCertificate)
+	assert.Equal(t, "cert-from-ref", lastCertificate.Id)
+}
+
+func TestBizApply_resolveLastCertificate_legacyRunIdLookup(t *testing.T) {
+	cert := &domain.Certificate{
+		Meta:             domain.Meta{Id: "cert-by-run"},
+		WorkflowId:       "wf1",
+		WorkflowRunId:    "run-apply",
+		WorkflowNodeId:   "node-apply",
+		ValidityNotAfter: time.Now().Add(60 * 24 * time.Hour),
+	}
+	certRepo := &mockCertificateRepo{
+		byRunAndNode: map[string]*domain.Certificate{
+			"run-apply|node-apply": cert,
+		},
+	}
+	outputRepo := &mockWorkflowOutputRepo{
+		byWorkflowAndNode: map[string]*domain.WorkflowOutput{
+			"wf1|node-apply": {
+				WorkflowId: "wf1",
+				RunId:      "run-apply",
+				NodeId:     "node-apply",
+				Succeeded:  true,
+				// No certificate ref in outputs — legacy path uses runId
+			},
+		},
+	}
+
+	ne := newTestApplyExecutor(certRepo, outputRepo)
+	execCtx := newTestApplyExecCtx("wf1", "run-next", "node-apply", domain.WorkflowNodeConfig{
+		"skipBeforeExpiryDays": 30,
+	})
+
+	_, lastCertificate, err := ne.getLastOutputArtifacts(execCtx)
+	require.NoError(t, err)
+	require.NotNil(t, lastCertificate)
+	assert.Equal(t, "cert-by-run", lastCertificate.Id)
+}
+
+func TestBizApply_Execute_skipPersistsCertificateOutput(t *testing.T) {
+	cert := &domain.Certificate{
+		Meta:             domain.Meta{Id: "cert-skip"},
+		WorkflowId:       "wf1",
+		WorkflowRunId:    "run-apply",
+		WorkflowNodeId:   "node-apply",
+		SubjectAltNames:  "example.com",
+		ValidityNotAfter: time.Now().Add(60 * 24 * time.Hour),
+	}
+	certRepo := &mockCertificateRepo{
+		byWorkflowAndNode: map[string]*domain.Certificate{
+			"wf1|node-apply": cert,
+		},
+		byId: map[string]*domain.Certificate{
+			"cert-skip": cert,
+		},
+	}
+	outputRepo := &mockWorkflowOutputRepo{}
+
+	ne := newTestApplyExecutor(certRepo, outputRepo)
+	execCtx := newTestApplyExecCtx("wf1", "run-skip", "node-apply", domain.WorkflowNodeConfig{
+		"domains":              []any{"example.com"},
+		"skipBeforeExpiryDays": 30,
+	})
+
+	execRes, err := ne.Execute(execCtx)
+	require.NoError(t, err)
+	require.NotNil(t, execRes)
+
+	var skipped bool
+	for _, v := range execRes.Variables {
+		if v.Scope == "node-apply" && v.Key == stateVarKeyNodeSkipped {
+			skipped = v.Value.(bool)
+		}
+	}
+	assert.True(t, skipped, "node should be skipped")
+
+	require.NotEmpty(t, execRes.Outputs)
+	foundPersistent := false
+	for _, out := range execRes.Outputs {
+		if out.Name == "certificate" {
+			assert.True(t, out.Persistent, "skipped apply must persist certificate output to survive history cleanup")
+			assert.Equal(t, domain.CollectionNameCertificate+"#cert-skip", out.Value)
+			foundPersistent = true
+		}
+	}
+	assert.True(t, foundPersistent, "expected a certificate output on skip")
+}
+
+func TestBizApply_checkCanSkip_reapplyWhenNearExpiry(t *testing.T) {
+	cert := &domain.Certificate{
+		Meta:             domain.Meta{Id: "cert-near"},
+		ValidityNotAfter: time.Now().Add(10 * 24 * time.Hour),
+	}
+	ne := newTestApplyExecutor(&mockCertificateRepo{}, &mockWorkflowOutputRepo{})
+	execCtx := newTestApplyExecCtx("wf1", "run1", "node-apply", domain.WorkflowNodeConfig{
+		"skipBeforeExpiryDays": 30,
+	})
+
+	skippable, reason := ne.checkCanSkip(execCtx, nil, cert)
+	assert.False(t, skippable)
+	assert.Contains(t, reason, "renewal window period has been reached")
+}

--- a/internal/workflow/engine/executor_bizupload.go
+++ b/internal/workflow/engine/executor_bizupload.go
@@ -72,6 +72,13 @@ func (ne *bizUploadNodeExecutor) Execute(execCtx *NodeExecutionContext) (*NodeEx
 	if skippable, reason := ne.checkCanSkip(execCtx, lastOutput, lastCertificate); skippable {
 		ne.logger.Info(fmt.Sprintf("skip this uploading, because %s", reason))
 
+		// Persist so skip runs keep a durable trail for the next skip decision.
+		// workflow_output rows cascade-delete with history cleanup; without a
+		// recent output the node would re-upload despite an existing certificate.
+		if lastCertificate != nil {
+			ne.setOuputsOfResult(execCtx, execRes, lastCertificate, true)
+		}
+
 		execRes.AddVariableWithScope(execCtx.Node.Id, stateVarKeyNodeSkipped, true, stateValTypeBoolean)
 		return execRes, nil
 	} else if reason != "" {
@@ -202,16 +209,12 @@ func (ne *bizUploadNodeExecutor) getLastOutputArtifacts(execCtx *NodeExecutionCo
 		return nil, nil, fmt.Errorf("failed to get last output record of node #%s: %w", execCtx.Node.Id, err)
 	}
 
-	if lastOutput != nil {
-		lastCertificate, err := ne.certificateRepo.GetByWorkflowRunIdAndNodeId(execCtx.Context(), lastOutput.RunId, lastOutput.NodeId)
-		if err != nil && !domain.IsRecordNotFoundError(err) {
-			return lastOutput, nil, fmt.Errorf("failed to get last certificate record of node #%s: %w", execCtx.Node.Id, err)
-		}
-
-		return lastOutput, lastCertificate, nil
+	lastCertificate, err := resolveLastCertificateForNode(execCtx, ne.certificateRepo, lastOutput)
+	if err != nil {
+		return lastOutput, nil, err
 	}
 
-	return lastOutput, nil, nil
+	return lastOutput, lastCertificate, nil
 }
 
 func (ne *bizUploadNodeExecutor) checkCanSkip(execCtx *NodeExecutionContext, lastOutput *domain.WorkflowOutput, lastCertificate *domain.Certificate) (_skip bool, _reason string) {


### PR DESCRIPTION
## Summary

Workflow apply (and upload) nodes decide whether to skip re-issuance by loading the last `workflow_output` for that node, then looking up the certificate only by that output’s run id. Two design gaps made that path intermittent:

1. **Skip never persisted a new output** — only a real apply wrote `workflow_output`, so the trail stayed tied to the original apply run.
2. **History cleanup cascade-deletes outputs** — `workflow_output.runRef` has `cascadeDelete: true`. When `cleanupWorkflowHistoryRuns` (or a manual run delete) removes the original apply run, the output disappears. The certificate itself survives (`workflowRunRef` is non-cascade), but the next run logs `no found last requested certificate, begin to apply` and re-issues even with 50–60 days left.

This matches [issue #1413](https://github.com/certimate-go/certimate/issues/1413): skip works until the apply run ages out of retention, then fails once, re-applies, and the cycle repeats.

### Fix

- **`resolveLastCertificateForNode`**: resolve certificate in order — (1) `certificate#id` ref on last output, (2) by `runId`+`nodeId`, (3) latest by `workflowId`+`nodeId` (survives history cleanup).
- **Persist certificate output on skip** so each successful skip refreshes a durable trail (and config comparison) while runs remain.
- Same lookup/persistence for upload skip (same fragile pattern).
- Regression tests for the #1413 scenario (output missing, cert still valid → skip).

## Test plan

- [x] `go test ./internal/workflow/engine/ -count=1`
- [x] `TestBizApply_resolveLastCertificate_fallbackWhenOutputMissing` — output gone, cert remains, skip still true
- [x] `TestBizApply_resolveLastCertificate_prefersOutputRefOverRunId` — skip-run output resolves via cert ref
- [x] `TestBizApply_Execute_skipPersistsCertificateOutput` — skip marks certificate output persistent
- [x] `TestBizApply_checkCanSkip_reapplyWhenNearExpiry` — near-expiry still forces re-apply
- [ ] Manual: set `skipBeforeExpiryDays=30`, schedule a workflow, delete the apply run’s history (or wait for retention cleanup), re-run — should skip while cert remains valid

Fixes #1413

---
[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-2F6FED)](https://github.com/EveryInc/compound-engineering-plugin)
