### PR TITLE
fix(provider): set APIPath when creating the Kubernetes REST client

### DIFF
--- a/pkg/core/deployer/providers/k8s-secret/k8s_secret.go
+++ b/pkg/core/deployer/providers/k8s-secret/k8s_secret.go
@@ -224,13 +224,23 @@ func createK8sClient(kubeConfig string) (*rest.RESTClient, error) {
 		return nil, err
 	}
 
-	// InClusterConfig does not set GroupVersion or NegotiatedSerializer,
-	// but both are required by rest.RESTClientFor.
+	// InClusterConfig does not set GroupVersion, NegotiatedSerializer or APIPath,
+	// but all of them are required by rest.RESTClientFor.
+	// Note that an empty APIPath makes every request target "/v1/namespaces/..."
+	// instead of "/api/v1/namespaces/...", which the API server rejects with
+	// 404 "the server could not find the requested resource".
 	if config.GroupVersion == nil {
 		config.GroupVersion = &schema.GroupVersion{Group: "", Version: "v1"}
 	}
 	if config.NegotiatedSerializer == nil {
 		config.NegotiatedSerializer = scheme.Codecs.WithoutConversion()
+	}
+	if config.APIPath == "" {
+		if config.GroupVersion.Group == "" {
+			config.APIPath = "/api"
+		} else {
+			config.APIPath = "/apis"
+		}
 	}
 
 	client, err := rest.RESTClientFor(config)

--- a/pkg/core/deployer/providers/k8s-secret/k8s_secret_client_test.go
+++ b/pkg/core/deployer/providers/k8s-secret/k8s_secret_client_test.go
@@ -1,0 +1,41 @@
+package k8ssecret
+
+import (
+	"strings"
+	"testing"
+)
+
+const testKubeConfig = `apiVersion: v1
+kind: Config
+clusters:
+  - name: test
+    cluster:
+      server: https://127.0.0.1:6443
+      insecure-skip-tls-verify: true
+contexts:
+  - name: test
+    context:
+      cluster: test
+      user: test
+current-context: test
+users:
+  - name: test
+    user:
+      token: test-token
+`
+
+// Secrets live in the core API group, which is served under "/api".
+// If APIPath is left empty, rest.RESTClientFor builds requests against
+// "/v1/namespaces/..." and the API server answers 404
+// ("the server could not find the requested resource").
+func TestCreateK8sClientSetsCoreAPIPath(t *testing.T) {
+	client, err := createK8sClient(testKubeConfig)
+	if err != nil {
+		t.Fatalf("createK8sClient() returned an unexpected error: %v", err)
+	}
+
+	const want = "/api/v1"
+	if got := client.Get().URL().Path; !strings.HasPrefix(got, want) {
+		t.Errorf("request path = %q, want it to start with %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #1424

### Problem

`createK8sClient` builds a bare `rest.RESTClient`, but `config.APIPath` is never assigned. `rest.RESTClientFor` requires it alongside `GroupVersion` and `NegotiatedSerializer`, and neither `rest.InClusterConfig()` nor `clientcmd.…ClientConfig()` populates it.

With an empty `APIPath` the versioned path resolves to `/v1` instead of `/api/v1`, so every request goes to `/v1/namespaces/<ns>/secrets/...` and the API server answers 404:

```
failed to create kubernetes secret: the server could not find the requested resource (post secrets <name>)
```

A confusing side effect: the deployer's `Get` also 404s, which is treated as "the secret does not exist", so it falls through to `Post` (create) even when the secret is already there — and that fails the same way.

This has affected the deployer since v0.4.23, when it switched from `kubernetes.NewForConfig` (the typed clientset sets `APIPath` internally) to a bare `rest.RESTClient`. #1412 supplied the missing `GroupVersion`, which changed the symptom from an initialization error into a 404 rather than restoring the deployer.

### Change

Set `APIPath` when empty — `/api` for the core group, `/apis` otherwise.

### Tests

Added `k8s_secret_client_test.go`, a unit test that requires no cluster: it builds the client from an inline kubeconfig and asserts the request path starts with `/api/v1`.

Confirmed it actually covers the bug:

```
# with the fix
=== RUN   TestCreateK8sClientSetsCoreAPIPath
--- PASS: TestCreateK8sClientSetsCoreAPIPath (0.00s)

# with the fix reverted
=== RUN   TestCreateK8sClientSetsCoreAPIPath
    k8s_secret_client_test.go:39: request path = "/v1", want it to start with "/api/v1"
--- FAIL: TestCreateK8sClientSetsCoreAPIPath (0.00s)
```

I have also been running a patched v0.4.30 build in production against Alibaba Cloud ACK: deploy nodes now log `Secrets.Get` → `Secrets.Put` and update existing secrets correctly, where previously they logged `Secrets.Get` → `Secrets.Post` and failed with the 404 above.
