### PR TITLE
Bugfix #1441

### DIFF
--- a/ui/src/components/workflow/designer/forms/BizDeployNodeConfigFieldsProviderNginxProxyManager.tsx
+++ b/ui/src/components/workflow/designer/forms/BizDeployNodeConfigFieldsProviderNginxProxyManager.tsx
@@ -66,7 +66,7 @@ const BizDeployNodeConfigFieldsProviderNginxProxyManager = () => {
 
         <Form.Item
           name={[parentNamePath, "hostType"]}
-          initialValue={initialValues.hostId}
+          initialValue={initialValues.hostType}
           label={t("workflow_node.deploy.form.nginxproxymanager_host_type.label")}
           rules={[formRule]}
         >
@@ -131,7 +131,7 @@ const getSchema = ({ i18n = getI18n() }: { i18n?: ReturnType<typeof getI18n> }) 
       switch (values.deployTarget) {
         case DEPLOY_TARGET_HOST:
           {
-            const scHostMatchPattern = z.coerce.number().int().positive();
+            const scHostMatchPattern = z.enum([HOST_MATCH_PATTERN_SPECIFIED, HOST_MATCH_PATTERN_CERTSAN]);
             const spHostMatchPattern = scHostMatchPattern.safeParse(values.hostMatchPattern);
             if (!spHostMatchPattern.success) {
               ctx.addIssue({


### PR DESCRIPTION
﻿
## 问题说明

我在配置 **Nginx Proxy Manager** 的证书部署节点时，部署目标选择“主机”后，保存配置会直接提示：

```text
无效输入：期望 数字，实际接收 NaN
```

这个错误会导致 Nginx Proxy Manager 的主机部署配置无法正常保存。v0.4.22是正常的，v0.4.23就坏了

开始我以为是 Host ID 填写有问题，但检查代码后发现，错误其实发生在 Certimate 的前端表单校验阶段，请求还没有发送到 Nginx Proxy Manager。

## 原因

`hostMatchPattern` 实际上是一个字符串字段，目前只有两个值：

```text
specified
certsan
```

但表单校验中却把它当成了数字处理：

```ts
const scHostMatchPattern = z.coerce.number().int().positive();
```

例如：

```text
Number("specified")
```

结果会变成：

```text
NaN
```

所以 Zod 最终就会提示：

```text
期望 数字，实际接收 NaN
```

同一个表单里还发现了另一个小问题：

```tsx
name={[parentNamePath, "hostType"]}
initialValue={initialValues.hostId}
```

`hostType` 的默认值误用了 `hostId`，这里应该使用：

```tsx
initialValue={initialValues.hostType}
```

否则默认的 `proxy` 主机类型也无法正确初始化。

## 本次修改

这次只修改了这两个地方：

1. `hostMatchPattern` 改为按照实际的字符串枚举进行校验：

```ts
z.enum([
  HOST_MATCH_PATTERN_SPECIFIED,
  HOST_MATCH_PATTERN_CERTSAN,
])
```

2. `hostType` 的默认值由：

```tsx
initialValues.hostId
```

改为：

```tsx
initialValues.hostType
```

`hostId` 和 `certificateId` 原本就是数字字段，因此它们的数字校验逻辑没有修改。

这个修改只涉及 Nginx Proxy Manager 部署表单的前端校验和默认值，不涉及 Nginx Proxy Manager API 或证书部署逻辑。




<!--

IMPORTANT! Before opening a Pull Request:
  - Please ensure you have read the `CONTRIBUTING.md` in the repository.
  - Please ensure you have opened an issue first, and got feedback from the maintainers.
  - Please ensure you are **NOT** fork within a GitHub organization, to [allowing edits by maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
  - By submitting this pull request, you agree to license your contributions under the terms of the MIT License.

---

重要必读！在提交 PR 之前：
  - 请确保已阅读仓库根目录下的 `CONTRIBUTING_zh.md` 贡献指南。
  - 请确保已创建了一个关联的 Issue，并等待来自维护者的反馈。
  - 请确保使用的是个人 fork、而非组织 fork 来创建 PR，以便维护者可以[编辑拉取请求](https://docs.github.com/zh/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork)。
  - 提交本 PR 即表示，您同意可依据 MIT 许可协议的相关条款对您的贡献进行授权。

-->
